### PR TITLE
[Refactor]  Update version to  v1.1.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
 
       - name: Get previous issue
-        uses: TakahashiIkki/previous-issue-finder@v1.0.0
+        uses: TakahashiIkki/previous-issue-finder@v1.1.0
         id: previous_issue
         with:
           label: daily
@@ -68,7 +68,7 @@ jobs:
         run: echo "CURRENT_DATE=$(TZ=Asia/Tokyo date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Get previous issue
-        uses: TakahashiIkki/previous-issue-finder@v1.0.0
+        uses: TakahashiIkki/previous-issue-finder@v1.1.0
         id: previous_issue
         with:
           label: daily


### PR DESCRIPTION
## WHY

The version of `README` is still out of date.

Prevents `Error: Input required and not supplied: tag` for users referring to the `README`.

Thank you for creating this wonderful action! @TakahashiIkki 